### PR TITLE
Extract fetcher call to separate method

### DIFF
--- a/src/Relation/RelationBuilder.php
+++ b/src/Relation/RelationBuilder.php
@@ -232,7 +232,7 @@ class RelationBuilder
         return $models;
     }
 
-    protected function fetchRelated(callable $fetcher, array $ids)
+    protected function fetchRelated($fetcher, array $ids)
     {
         return call_user_func($fetcher, $ids);
     }

--- a/src/Relation/RelationBuilder.php
+++ b/src/Relation/RelationBuilder.php
@@ -167,8 +167,7 @@ class RelationBuilder
             return $models;
         }
 
-        // Fetch related
-        $related = call_user_func($config['fetcher'], $ids);
+        $related = $this->fetchRelated($config['fetcher'], $ids);
 
         // Map relation
         return $this->combine($models, $related, $config);
@@ -231,5 +230,10 @@ class RelationBuilder
         $this->mapRelation($rhsModels, $rhs, $force);
 
         return $models;
+    }
+
+    protected function fetchRelated(callable $fetcher, array $ids)
+    {
+        return call_user_func($fetcher, $ids);
     }
 }


### PR DESCRIPTION
This small refactoring is a preliminary step to ease migration to DIC in www-site

When configuring relations in DAL a 'fetcher' option is used to specify which method should be use to fetch related models. As of now, it accepts strings in the form `Repository::getSomethingById`.  

Since we want to move away from static methods we should be able to change this behavior in www-site, where we have a spRelationBuilder class that extends RelationBuilder. This refactoring allows overriding only the fetchRelated method
